### PR TITLE
仅搜索帖子，排除用户主页、版块等无关页面

### DIFF
--- a/redirect.js
+++ b/redirect.js
@@ -8,6 +8,7 @@
       ][0] +
       "site%3A" +
       location.hostname +
+      "/d/" +
       "+" +
       search.replace(/.*[\?&]q=/, "");
     // window.open(href, "_blank");


### PR DESCRIPTION
经过在药学论坛使用该插件的几个月测试，发现有不少搜索结果指向了版块页面甚至是论坛主页。而用户使用搜索功能一般是要查找 https://example.com/d/ 内的帖子，故加了两行，使用户搜索直达帖子页面